### PR TITLE
Fix webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -75,7 +75,8 @@ module.exports = {
   ],
   devServer: {
     hot: false,
-    inline: false,
-    writeToDisk: true,
+    devMiddleware: {
+      writeToDisk: true
+    }
   },
 };


### PR DESCRIPTION
This fixes the errors ```Invalid options object. Dev Server has been initialized using an options object that does not match the API schema.``` by removing the inline property and moving the writeToDisk property to the devMiddleware scope.