### PR TITLE
Section names in error message

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -306,28 +306,28 @@
     "message": "Failed to load statistics"
   },
   "errorFailedToLoadIsolationPerDomain": {
-    "message": "Failed to load Isolation: Per Domain settings"
+    "message": "Failed to load \"Isolation: Per Domain\" settings"
   },
   "errorFailedToLoadIsolationGlobal": {
-    "message": "Failed to load Isolation: Global settings"
+    "message": "Failed to load \"Isolation: Global\" settings"
   },
   "errorFailedToSave": {
     "message": "Failed to save"
   },
   "errorFailedToLoadGeneral": {
-    "message": "Failed to load General settings"
+    "message": "Failed to load \"General\" settings"
   },
   "errorImportFileNotFound": {
     "message": "Import error: File not found"
   },
   "errorFailedToLoadAdvancedMisc": {
-    "message": "Failed to load Advanced Settings"
+    "message": "Failed to load \"Advanced Settings\""
   },
   "errorFailedToLoadAdvancedCookies": {
-    "message": "Failed to load Cookie Injection settings"
+    "message": "Failed to load \"Cookie Injection\" settings"
   },
   "errorFailedToLoadActions": {
-    "message": "Failed to load Actions"
+    "message": "Failed to load \"Actions\""
   },
   "savedMessage": {
     "message": "Saved"
@@ -839,10 +839,10 @@
     "message": "Open new \"Deletes History Temporary Containers\" with Left Mouse clicks instead of Temporary Containers"
   },
   "errorFailedToLoadAdvancedScripts": {
-    "message": "Failed to load Script Injection settings"
+    "message": "Failed to load \"Script Injection\" settings"
   },
   "errorFailedToLoadAdvancedDeleteHistory": {
-    "message": "Failed to load Deletes History Containers settings"
+    "message": "Failed to load \"Deletes History Containers\" settings"
   },
   "managedStorageNoticeTitle": {
     "message": "Settings Managed by Policy"


### PR DESCRIPTION
This does two things:

* Quote section names in error messages.
* Use the name of the tab as shown on the left instead of its "internal" name.

Feel free to discard this if you don't like it.

Note: The other languages (ru, tr) might also profit from this.