### PR TITLE
Show error messages indefinitely

### DIFF
--- a/src/ui/shared/utils.ts
+++ b/src/ui/shared/utils.ts
@@ -218,11 +218,16 @@ export function formatBytes(bytes: number, decimals = 2): string {
 }
 
 /**
- * Show a message to the user
+ * Show a message to the user.
+ *
+ * If the duration is negative, then the message is shown indefinitely until
+ * overwritten by another message.
+ *
  * @param message - The message to show
  * @param type - The type of message (error, success, warning)
+ * @param duration - Time in milliseconds to show the message.
  */
-export function showMessage(message: string, type = ''): void {
+export function showMessage(message: string, type = '', duration=3000): void {
   const container = document.getElementById('message-container');
   const messageEl = document.getElementById('message');
 
@@ -234,9 +239,11 @@ export function showMessage(message: string, type = ''): void {
   container.className = `message-container ${type}`;
   container.classList.remove('hidden');
 
-  setTimeout(() => {
-    container.classList.add('hidden');
-  }, 3000);
+  if (duration >= 0) {
+    setTimeout(() => {
+      container.classList.add('hidden');
+    }, duration);
+  }
 }
 
 /**
@@ -244,7 +251,7 @@ export function showMessage(message: string, type = ''): void {
  * @param message - The error message
  */
 export function showError(message: string): void {
-  showMessage(message, 'error');
+  showMessage(message, 'error', -1);
 }
 
 /**


### PR DESCRIPTION
Error messages are important enough to not be hidden after 3s. Keep an error message visible until another message overrides it.