### PR TITLE
fix: compatibility with Container Redirect (fixes #44, partly fixes #38)

### DIFF
--- a/src/background/external-addons.ts
+++ b/src/background/external-addons.ts
@@ -539,6 +539,14 @@ export const addons: Map<
     },
   ],
   [
+    '{e70111b3-b362-47a7-bbdc-a6fb7249d47a}',
+    {
+      name: 'Container Redirect',
+      enabled: false,
+      version: false,
+    },
+  ],
+  [
     'block_outside_container@jspenguin.org',
     {
       name: 'Block sites outside container',

--- a/src/background/request.ts
+++ b/src/background/request.ts
@@ -344,6 +344,23 @@ export class Request {
       }
     }
 
+    if (this.management.addons.get('{e70111b3-b362-47a7-bbdc-a6fb7249d47a}')?.enabled) {
+      try {
+        const hostmap = await browser.runtime.sendMessage('{e70111b3-b362-47a7-bbdc-a6fb7249d47a}', {
+          method: 'getHostMap',
+          url: request.url,
+        });
+        if (typeof hostmap === 'object' && hostmap.cookieStoreId && hostmap.enabled) {
+          this.debug('[handleRequest] assigned with container-redirect we do nothing', hostmap);
+          return true;
+        } else {
+          this.debug('[handleRequest] not assigned with container-redirect', hostmap);
+        }
+      } catch (error) {
+        this.debug('[handleRequest] contacting container-redirect failed, probably old version', error);
+      }
+    }
+
     if (this.management.addons.get('block_outside_container@jspengun.org')?.enabled) {
       try {
         const response = await browser.runtime.sendMessage('block_outside_container@jspenguin.org', {


### PR DESCRIPTION
## Pull Request Checklist

Please ensure your PR meets the following requirements:

### Commit Message Format

- [x] All commit messages follow the conventional commit format: `type: description`
- [x] Valid types:
- **build**: Changes that affect the build system or external dependencies
- **chore**: Other changes that do not modify source or test files
- **ci**: Changes to CI configuration files and scripts
- **docs**: Changes are only to documentation
- **feat**: A new feature is introduced
- **fix**: A bug fix is implemented
- **perf**: A code change that improves performance
- **refactor**: A code change that neither fixes a bug nor adds a feature
- **revert**: For when a change has been reverted
- **style**: Code formatting, white-space, or other formatting changes
- **test**: Adding missing tests or correcting existing tests

### Code Quality

- [x] Code has been formatted with Prettier
- [x] All linting checks pass
- [x] All tests pass

## Description

Adds compatibility with Container Redirect extension, similar to the existing Containerise support.

The way was cleared for this with https://github.com/max-dw-i/container-redirect/pull/8 allowing Temporary Containers Plus access to the API, but the IDs are hardcoded in this extension as well, so it required a patch here too. Logic is straightforwardly copied from the logic to handle Containerise.

- Fixes #44 by not opening temporary container tabs for URLs configured in Container Redirect.
- Fixes #38 for Container Redirect, but does not solve the issue for Containerise since the problem there is that Containerise doesn't recognize Temporary Containers Plus.

## Type of Change

Not totally sure which this falls under, I've gone with `fix` for now because it feels more like resolving an issue than adding something totally new.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## Testing

Manually built and installed extension, then spammed opening links with containers set which previously had caused issues.