### PR TITLE
feat: support %NEW_TEMP_CONTAINER% marker for external container creation

### DIFF
--- a/src/background/container.ts
+++ b/src/background/container.ts
@@ -2,7 +2,7 @@ import { TemporaryContainers } from './tmp';
 import { delay, psl } from './lib';
 import { Storage } from './storage';
 import { Tabs } from './tabs';
-import { CONTAINER_COLORS, CONTAINER_ICONS } from '~/shared';
+import { CONTAINER_COLORS, CONTAINER_ICONS, CONTAINER_MARK } from '~/shared';
 import {
   ContainerColor,
   ContainerIcon,
@@ -147,6 +147,34 @@ export class Container {
     } catch (error) {
       this.debug('[createTabInTempContainer] error while creating container', containerOptions.name, error);
       throw error;
+    }
+  }
+
+  async onCreated(changeInfo: { contextualIdentity: browser.contextualIdentities.ContextualIdentity }): Promise<void> {
+    const { contextualIdentity } = changeInfo;
+    if (contextualIdentity.name !== CONTAINER_MARK) {
+      return;
+    }
+
+    this.debug('[onCreated] detected %NEW_TEMP_CONTAINER% marker, converting to temp container');
+    const containerOptions = this.generateContainerNameIconColor();
+
+    if (containerOptions.number) {
+      this.storage.local.tempContainersNumbers.push(containerOptions.number);
+    }
+
+    try {
+      const updated = await browser.contextualIdentities.update(contextualIdentity.cookieStoreId, {
+        name: containerOptions.name,
+        icon: containerOptions.icon,
+        color: containerOptions.color,
+      });
+      this.debug('[onCreated] container converted', updated);
+
+      this.storage.local.tempContainers[contextualIdentity.cookieStoreId] = containerOptions;
+      await this.storage.persist();
+    } catch (error) {
+      this.debug('[onCreated] error converting marked container', error);
     }
   }
 

--- a/src/background/event-listeners.ts
+++ b/src/background/event-listeners.ts
@@ -72,6 +72,9 @@ export class EventListeners {
       this.wrap(browser.runtime.onMessageExternal, this.background.runtime, 'onMessageExternal')
     );
     browser.runtime.onStartup.addListener(this.wrap(browser.runtime.onStartup, this.background.runtime, 'onStartup'));
+    browser.contextualIdentities.onCreated.addListener(
+      this.wrap(browser.contextualIdentities.onCreated, this.background.container, 'onCreated')
+    );
 
     this.registerPermissionedListener();
   }

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -55,6 +55,12 @@ export const IGNORED_DOMAINS_DEFAULT = ['getpocket.com', 'addons.mozilla.org'];
 
 export const REDIRECTOR_DOMAINS_DEFAULT = ['t.co', 'outgoing.prod.mozaws.net', 'slack-redir.net', 'away.vk.com'];
 
+// Marker name used by "Open external links in a container" and similar extensions.
+// When a container is created with this exact name, it is automatically converted
+// into a proper temporary container.
+// Usage: firefox "ext+container:name=%NEW_TEMP_CONTAINER%&url=https://example.com/"
+export const CONTAINER_MARK = '%NEW_TEMP_CONTAINER%';
+
 export const formatBytes = (bytes: number, decimals = 2): string => {
   // https://stackoverflow.com/a/18650828
   if (bytes == 0) {

--- a/test/background.container-mark.test.ts
+++ b/test/background.container-mark.test.ts
@@ -1,0 +1,74 @@
+import { sinon, expect, loadBackground } from './setup';
+import { CONTAINER_MARK } from '~/shared';
+
+describe('container mark (%NEW_TEMP_CONTAINER%)', () => {
+  it('should convert a container created with the marker name into a temp container', async () => {
+    const { browser, tmp: background } = await loadBackground();
+
+    const fakeCookieStoreId = 'firefox-container-mark-1';
+
+    browser.contextualIdentities.update.resolves({
+      cookieStoreId: fakeCookieStoreId,
+      name: 'tmp1',
+      color: 'blue',
+      icon: 'fingerprint',
+    });
+
+    // Simulate external creation of a container named %NEW_TEMP_CONTAINER%
+    const [promise] = browser.contextualIdentities.onCreated.addListener.yield({
+      contextualIdentity: {
+        cookieStoreId: fakeCookieStoreId,
+        name: CONTAINER_MARK,
+        color: 'toolbar',
+        icon: 'fingerprint',
+      },
+    }) as unknown as any[];
+    await promise;
+
+    // Should have called update to rename the container
+    browser.contextualIdentities.update.should.have.been.calledOnce;
+    const [updateId, updateDetails] = browser.contextualIdentities.update.firstCall.args;
+    expect(updateId).to.equal(fakeCookieStoreId);
+    expect(updateDetails.name).to.not.equal(CONTAINER_MARK);
+    expect(updateDetails.name).to.be.a('string');
+    expect(updateDetails.color).to.be.a('string');
+    expect(updateDetails.icon).to.be.a('string');
+
+    // Should be tracked as a temporary container
+    expect(background.storage.local.tempContainers[fakeCookieStoreId]).to.exist;
+    expect(background.storage.local.tempContainers[fakeCookieStoreId].clean).to.be.true;
+  });
+
+  it('should ignore containers created with regular names', async () => {
+    const { browser } = await loadBackground();
+
+    const [promise] = browser.contextualIdentities.onCreated.addListener.yield({
+      contextualIdentity: {
+        cookieStoreId: 'firefox-container-regular-1',
+        name: 'My Personal Container',
+        color: 'blue',
+        icon: 'fingerprint',
+      },
+    }) as unknown as any[];
+    await promise;
+
+    // Should NOT have called update
+    browser.contextualIdentities.update.should.not.have.been.called;
+  });
+
+  it('should ignore containers with names that contain but do not exactly match the marker', async () => {
+    const { browser } = await loadBackground();
+
+    const [promise] = browser.contextualIdentities.onCreated.addListener.yield({
+      contextualIdentity: {
+        cookieStoreId: 'firefox-container-partial-1',
+        name: `prefix-${CONTAINER_MARK}-suffix`,
+        color: 'blue',
+        icon: 'fingerprint',
+      },
+    }) as unknown as any[];
+    await promise;
+
+    browser.contextualIdentities.update.should.not.have.been.called;
+  });
+});


### PR DESCRIPTION
## Summary

- Adds support for the `%NEW_TEMP_CONTAINER%` marker from [Simple Temporary Containers](https://github.com/ninevra/Simple-Temporary-Containers), enabling integration with extensions like [Open external links in a container](https://addons.mozilla.org/en-US/firefox/addon/open-url-in-container/)
- When a container is created with the name `%NEW_TEMP_CONTAINER%`, it is automatically converted into a proper temporary container with the user's configured naming/color/icon preferences
- Enables opening URLs in fresh ephemeral containers from the command line: `firefox "ext+container:name=%NEW_TEMP_CONTAINER%&url=https://example.com/"`

## Implementation

Three files changed (~40 lines of new code):

1. **`src/shared.ts`** — Added `CONTAINER_MARK` constant
2. **`src/background/container.ts`** — Added `onCreated()` handler that detects the marker name and converts the container using `contextualIdentities.update()`, reusing the existing `generateContainerNameIconColor()` infrastructure
3. **`src/background/event-listeners.ts`** — Registered `contextualIdentities.onCreated` listener using the existing `wrap()` pattern for proper initialization timing

No new permissions required — `contextualIdentities` is already declared in the manifest.

## Test plan

- [x] All 1523 tests pass (1520 existing + 3 new)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Webpack build succeeds
- [x] ESLint passes (0 errors)
- [ ] Manual test with "Open external links in a container" extension
- [ ] Verify container cleanup still works after conversion
- [ ] Verify container respects user's naming prefix, color, and icon preferences

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)